### PR TITLE
Add [MarshalAs(UnmanagedType.U1)] to m_IsDisposed

### DIFF
--- a/Runtime/Bindings/FastNoise2.cs
+++ b/Runtime/Bindings/FastNoise2.cs
@@ -874,7 +874,7 @@ namespace FastNoise2.Bindings
         [DllImport(NATIVE_LIB)] internal static extern IntPtr fnGetMetadataHybridDescription(int id, int hybridIndex);
         [DllImport(NATIVE_LIB)] internal static extern float  fnGetMetadataHybridDefault(int id, int hybridIndex);
 #endif // FN2_USER_SIGNED
-
+        [MarshalAs(UnmanagedType.U1)]
         private bool m_IsDisposed;
         public readonly bool IsCreated => !m_IsDisposed && mNodeHandle != IntPtr.Zero;
     }


### PR DESCRIPTION
Unity throws error when passing FastNoise by ref fixed with
```cs
[MarshalAs(UnmanagedType.U1)]
private bool m_IsDisposed;
```
# Error:
Field `FastNoise.m_IsDisposed` of type `bool` is not blittable. When compiling a method for use as a function pointer, only blittable types can be used in the method signature, including parameters and return type. To fix this issue, add the following attribute to this `bool` field: `[MarshalAs(UnmanagedType.U1)]`. Alternatively, use a pointer - `FastNoise2.Bindings.FastNoise*` - instead of ref -